### PR TITLE
feat: system for supporting custom webhook urls at the block level

### DIFF
--- a/packages/join-block/src/Services/JoinService.php
+++ b/packages/join-block/src/Services/JoinService.php
@@ -86,19 +86,22 @@ class JoinService
             }
         }
 
-        $webhookUrl = Settings::get("WEBHOOK_URL");
-        if ($webhookUrl) {
-            $webhookData = apply_filters('ck_join_flow_pre_webhook_post', [
-                "headers" => [
-                    'Content-Type' => 'application/json',
-                ],
-                "body" => json_encode($data)
-            ]);
-            $webhookResponse = wp_remote_post($webhookUrl, $webhookData);
-            if ($webhookResponse instanceof \WP_Error) {
-                $error = $webhookResponse->get_error_message();
-                $joinBlockLog->error('Webhook ' . $webhookUrl . ' failed: ' . $error);
-                throw new \Exception($error);
+        $webhookUuid = $data['webhookUuid'] ?? '';
+        if ($webhookUuid) {
+            $webhookUrl = Settings::getWebhookUrl($webhookUuid);
+            if ($webhookUrl) {
+                $webhookData = apply_filters('ck_join_flow_pre_webhook_post', [
+                    "headers" => [
+                        'Content-Type' => 'application/json',
+                    ],
+                    "body" => json_encode($data)
+                ]);
+                $webhookResponse = wp_remote_post($webhookUrl, $webhookData);
+                if ($webhookResponse instanceof \WP_Error) {
+                    $error = $webhookResponse->get_error_message();
+                    $joinBlockLog->error('Webhook ' . $webhookUrl . ' failed: ' . $error);
+                    throw new \Exception($error);
+                }
             }
         }
 

--- a/packages/join-flow/src/app.tsx
+++ b/packages/join-flow/src/app.tsx
@@ -172,7 +172,8 @@ const getInitialState = (): FormSchema => {
     ...getTestDataIfEnabled(),
     ...getDefaultState(),
     ...getSavedState(),
-    ...getProvidedStateFromQueryParams()
+    ...getProvidedStateFromQueryParams(),
+    webhookUuid: getEnv('WEBHOOK_UUID')
   } as any;
 };
 

--- a/packages/join-flow/src/env.ts
+++ b/packages/join-flow/src/env.ts
@@ -16,6 +16,7 @@ interface StaticEnv {
     USE_CHARGEBEE: boolean;
     USE_GOCARDLESS: boolean;
     USE_TEST_DATA: string;
+    WEBHOOK_UUID: string; // Connected to a URL in the wp_options table: `SELECT option_name FROM wp_options where option_value = :uuid`
     WP_REST_API: string;
 }
 
@@ -43,6 +44,7 @@ const staticEnv: StaticEnv = {
     USE_CHARGEBEE: parseBooleanEnvVar("REACT_APP_USE_CHARGEBEE"),
     USE_GOCARDLESS: parseBooleanEnvVar("REACT_APP_USE_GOCARDLESS"),
     USE_TEST_DATA: process.env.REACT_APP_POSTCODE_API_KEY || '',
+    WEBHOOK_UUID: process.env.WEBHOOK_UUID || '',
     WP_REST_API: ''
 }
 

--- a/packages/join-flow/src/pages/payment-details.page.tsx
+++ b/packages/join-flow/src/pages/payment-details.page.tsx
@@ -45,8 +45,7 @@ const DirectDebitPaymentPage: StagerComponent<FormSchema> = ({
     },
     resolver: validate(PaymentMethodDDSchema)
   });
-  const organisationName =  getEnv('ORGANISATION_NAME');
-  const organisation = `GC re ${organisationName}`;
+  const organisation = getEnv('ORGANISATION_NAME');
 
   return (
     <form


### PR DESCRIPTION
Associates webhook URLs with UUIDs and stores them in the wp_options table, so the UUID can be sent to the front-end and associated with the submission without exposing the (secret) webhook URL.