### PR TITLE
CK-3728 feat: add action network support

### DIFF
--- a/packages/join-block/composer.json
+++ b/packages/join-block/composer.json
@@ -12,7 +12,8 @@
     "http-interop/http-factory-guzzle": "^1.2",
     "chargebee/chargebee-php": "^3.23",
     "stripe/stripe-php": "^16.1",
-    "mailchimp/marketing": "^3.0"
+    "mailchimp/marketing": "^3.0",
+    "guzzlehttp/guzzle": "^7.9"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^3.5",

--- a/packages/join-block/composer.lock
+++ b/packages/join-block/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "62669418c926d5eb3d841234d6687c8a",
+    "content-hash": "48e3d5249059637afb76b00b672af22a",
     "packages": [
         {
             "name": "auth0/auth0-php",

--- a/packages/join-block/src/Services/ActionNetworkService.php
+++ b/packages/join-block/src/Services/ActionNetworkService.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace CommonKnowledge\JoinBlock\Services;
+
+use CommonKnowledge\JoinBlock\Settings;
+use GuzzleHttp\Client;
+
+class ActionNetworkService
+{
+    public static function signup($data)
+    {
+        global $joinBlockLog;
+
+        $joinBlockLog->info("Adding {$data['email']} to Mailchimp");
+
+        if ($data['isUpdateFlow']) {
+            $anData = [
+                "person" => [
+                    "email_addresses" => [
+                        "address" => $data["email"],
+                        "primary" => true,
+                        "status" => $data["contactByEmail"] ? "subscribed" : "unsubscribed"
+                    ]
+                ]
+            ];
+        } else {
+            $anData = [
+                "person" => [
+                    "email_addresses" => [[
+                        "address" => $data["email"],
+                        "primary" => true,
+                        "status" => $data["contactByEmail"] ? "subscribed" : "unsubscribed"
+                    ]],
+                    "phone_numbers" => [[
+                        "number" => $data["phoneNumber"],
+                        "primary" => true,
+                        "status" => $data["contactByPhone"] ? "subscribed" : "unsubscribed"
+                    ]],
+                    "given_name" => $data["firstName"],
+                    "family_name" => $data["lastName"],
+                    "postal_addresses" => [[
+                        "primary" => true,
+                        "address_lines" => [
+                            $data["addressLine1"],
+                            $data["addressLine2"],
+                        ],
+                        "locality" => $data["addressCity"],
+                        "postal_code" => $data["addressPostcode"],
+                        "country" => $data["addressCountry"]
+                    ]]
+                ]
+            ];
+        }
+
+        $client = new Client();
+        $client->request(
+            "POST",
+            "https://actionnetwork.org/api/v2/people/",
+            [
+                "headers" => [
+                    "OSDI-API-Token" => Settings::get("ACTION_NETWORK_API_KEY")
+                ],
+                "json" => $anData,
+            ]
+        );
+    }
+}

--- a/packages/join-block/src/Services/JoinService.php
+++ b/packages/join-block/src/Services/JoinService.php
@@ -220,10 +220,22 @@ class JoinService
             $email = $data['email'];
             $joinBlockLog->info("Processing Mailchimp signup request for $email");
             try {
-                MailchimpService::signup($email);
+                MailchimpService::signup($data);
                 $joinBlockLog->info("Completed Mailchimp signup request for $email");
             } catch (\Exception $exception) {
                 $joinBlockLog->error("Mailchimp error for email $email: " . $exception->getMessage());
+                throw $exception;
+            }
+        }
+
+        if (Settings::get("USE_ACTION_NETWORK")) {
+            $email = $data['email'];
+            $joinBlockLog->info("Processing Action Network signup request for $email");
+            try {
+                ActionNetworkService::signup($data);
+                $joinBlockLog->info("Completed Action Network signup request for $email");
+            } catch (\Exception $exception) {
+                $joinBlockLog->error("Action Network error for email $email: " . $exception->getMessage());
                 throw $exception;
             }
         }

--- a/packages/join-block/src/Services/MailchimpService.php
+++ b/packages/join-block/src/Services/MailchimpService.php
@@ -7,11 +7,13 @@ use CommonKnowledge\JoinBlock\Settings;
 
 class MailchimpService
 {
-    public static function signup($email)
+    public static function signup($data)
     {
         global $joinBlockLog;
 
-        $joinBlockLog->info("Adding $email to Mailchimp");
+        $email = $data['email'];
+
+        $joinBlockLog->info("Adding {$data['email']} to Mailchimp");
 
         $mailchimp_api_key = Settings::get("MAILCHIMP_API_KEY");
         $mailchimp_audience_id = Settings::get("MAILCHIMP_AUDIENCE_ID");
@@ -24,10 +26,29 @@ class MailchimpService
             'server' => $server
         ]);
 
+        if ($data['isUpdateFlow']) {
+            $mergeFields = [];
+        } else {
+            $mergeFields = [
+                "FNAME" => $data['firstName'],
+                "LNAME" => $data['lastName'],
+                "PHONE" => $data['phoneNumber'],
+                "ADDRESS" => [
+                    "addr1" => $data["addressLine1"],
+                    "addr2" => $data["addressLine2"],
+                    "city" => $data["addressCity"],
+                    "state" => "",
+                    "zip" => $data["addressPostcode"],
+                    "country" => $data["addressCountry"]
+                ]
+            ];
+        }
+
         try {
             $mailchimp->lists->addListMember($mailchimp_audience_id, [
                 "email_address" => $email,
                 "status" => "subscribed",
+                "merge_fields" => $mergeFields
             ]);
             $joinBlockLog->info("$email added to Mailchimp");
         } catch (\GuzzleHttp\Exception\ClientException $e) {

--- a/packages/join-block/src/Settings.php
+++ b/packages/join-block/src/Settings.php
@@ -45,8 +45,10 @@ class Settings
             Field::make('checkbox', 'use_chargebee'),
             Field::make('checkbox', 'use_stripe', 'Use Stripe')
                 ->set_help_text('Use Stripe as a payment provider'),
+            Field::make('checkbox', 'use_action_network', 'Use Action Network')
+                ->set_help_text('Save sign-ups in Action Network'),
             Field::make('checkbox', 'use_mailchimp', 'Use Mailchimp')
-                ->set_help_text('Save responses in Mailchimp')
+                ->set_help_text('Save sign-ups in Mailchimp')
         ];
 
         $membership_plans_fields = [
@@ -105,6 +107,9 @@ class Settings
             Field::make('separator', 'mailchimp', 'Mailchimp'),
             Field::make('text', 'mailchimp_api_key', 'Mailchimp API key')->set_help_text('Instructions here under "Generate an API key": https://eepurl.com/dyijVH'),
             Field::make('text', 'mailchimp_audience_id', 'Mailchimp audience ID')->set_help_text('Instructions here under "Find Your Audience ID": https://eepurl.com/dyilJL'),
+
+            Field::make('separator', 'action_network', 'Action Network'),
+            Field::make('text', 'action_network_api_key', 'Action Network API key')->set_help_text('Instructions here: https://help.actionnetwork.org/hc/en-us/articles/203853205-Does-the-Action-Network-have-an-API-and-how-do-I-access-it'),
 
             Field::make('separator', 'webhook'),
             Field::make('text', 'step_webhook_url')->set_help_text('Webhook called after each step of the form'),


### PR DESCRIPTION
## Description
Adds support to add new members to action network.

## Motivation and Context
https://linear.app/commonknowledge/issue/CK-3728/action-network-integration

## How Can It Be Tested?
- Install the join plugin in WordPress
- Enable Action Network in settings and add an API key in integrations
- Sign up through the form and check the user appears in action network
