### PR TITLE
Remove Unconfirmed default tag from Zetkin signups

### DIFF
--- a/packages/join-block/join.php
+++ b/packages/join-block/join.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name:     Common Knowledge Join Flow
  * Description:     Common Knowledge join flow plugin.
- * Version:         1.4.2
+ * Version:         1.4.3
  * Author:          Common Knowledge <hello@commonknowledge.coop>
  * Text Domain:     common-knowledge-join-flow
  * License: GPLv2 or later

--- a/packages/join-block/readme.txt
+++ b/packages/join-block/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, subscription, join
 Contributors: commonknowledgecoop
 Requires at least: 5.4
 Tested up to: 6.8
-Stable tag: 1.4.2
+Stable tag: 1.4.3
 Requires PHP: 8.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -107,6 +107,8 @@ Need help? Contact us at [hello@commonknowledge.coop](mailto:hello@commonknowled
 
 == Changelog ==
 
+= 1.4.3 =
+* Remove hard-coded "Unconfirmed" default tag previously appended to every new Zetkin person
 = 1.4.2 =
 *
 = 1.4.1 =

--- a/packages/join-block/src/Services/ZetkinService.php
+++ b/packages/join-block/src/Services/ZetkinService.php
@@ -152,7 +152,6 @@ class ZetkinService
 
             $existingTags = self::getTags($baseUrl, $orgId, $accessToken);
 
-            $addTags[] = "Unconfirmed";
             $addTagIds = [];
             foreach ($addTags as $tag) {
                 $existingTag = self::findOrCreateTag($baseUrl, $orgId, $existingTags, $tag, $accessToken);

--- a/packages/join-flow/src/index.tsx
+++ b/packages/join-flow/src/index.tsx
@@ -24,7 +24,7 @@ const init = () => {
   const sentryDsn = getEnvStr("SENTRY_DSN")
   Sentry.init({
     dsn: sentryDsn,
-    release: "1.4.1"
+    release: "1.4.3"
   });
 
   if (getEnv('USE_CHARGEBEE')) {

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@ This is a monorepo containing packages that together provide a full membership a
 - `packages/join-block` — A WordPress Gutenberg plugin containing the join form block(s) and the backend logic that processes memberships, payments, and CRM integrations.
 - `packages/join-e2e` — End-to-end tests (Puppeteer).
 
-**Current version:** 1.4.2
+**Current version:** 1.4.3
 
 ---
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -20,7 +20,7 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 README_TXT="$PROJECT_ROOT/packages/join-block/readme.txt"
 JOIN_PHP="$PROJECT_ROOT/packages/join-block/join.php"
 INDEX_TSX="$PROJECT_ROOT/packages/join-flow/src/index.tsx"
-README_MD="$PROJECT_ROOT/README.md"
+README_MD="$PROJECT_ROOT/readme.md"
 
 if [ ! -f "$README_TXT" ]; then
     print_error "readme.txt not found at $README_TXT"
@@ -38,7 +38,7 @@ if [ ! -f "$INDEX_TSX" ]; then
 fi
 
 if [ ! -f "$README_MD" ]; then
-    print_error "README.md not found at $README_MD"
+    print_error "readme.md not found at $README_MD"
     exit 1
 fi
 
@@ -118,7 +118,7 @@ print_step "3. Updating index.tsx (Sentry release)"
 sed -i.bak "s/release: \".*\"/release: \"$NEW_VERSION\"/" "$INDEX_TSX"
 rm -f "$INDEX_TSX.bak"
 
-print_step "4. Updating README.md (Current version)"
+print_step "4. Updating readme.md (Current version)"
 sed -i.bak "s/^\*\*Current version:\*\* .*/**Current version:** $NEW_VERSION/" "$README_MD"
 rm -f "$README_MD.bak"
 
@@ -128,7 +128,7 @@ echo "Files updated:"
 echo "  - packages/join-block/readme.txt"
 echo "  - packages/join-block/join.php"
 echo "  - packages/join-flow/src/index.tsx"
-echo "  - README.md"
+echo "  - readme.md"
 echo ""
 echo "Next steps:"
 echo "  1. Review changes: git diff"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -20,6 +20,7 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 README_TXT="$PROJECT_ROOT/packages/join-block/readme.txt"
 JOIN_PHP="$PROJECT_ROOT/packages/join-block/join.php"
 INDEX_TSX="$PROJECT_ROOT/packages/join-flow/src/index.tsx"
+README_MD="$PROJECT_ROOT/README.md"
 
 if [ ! -f "$README_TXT" ]; then
     print_error "readme.txt not found at $README_TXT"
@@ -33,6 +34,11 @@ fi
 
 if [ ! -f "$INDEX_TSX" ]; then
     print_error "index.tsx not found at $INDEX_TSX"
+    exit 1
+fi
+
+if [ ! -f "$README_MD" ]; then
+    print_error "README.md not found at $README_MD"
     exit 1
 fi
 
@@ -73,7 +79,7 @@ if [ ${#CHANGELOG_ENTRIES[@]} -eq 0 ]; then
     print_warning "No changelog entries provided"
 fi
 
-print_step "Updating version to $NEW_VERSION in 3 files..."
+print_step "Updating version to $NEW_VERSION in 4 files..."
 
 print_step "1. Updating readme.txt (Stable tag and changelog)"
 sed -i.bak "s/^Stable tag: .*/Stable tag: $NEW_VERSION/" "$README_TXT"
@@ -112,12 +118,17 @@ print_step "3. Updating index.tsx (Sentry release)"
 sed -i.bak "s/release: \".*\"/release: \"$NEW_VERSION\"/" "$INDEX_TSX"
 rm -f "$INDEX_TSX.bak"
 
+print_step "4. Updating README.md (Current version)"
+sed -i.bak "s/^\*\*Current version:\*\* .*/**Current version:** $NEW_VERSION/" "$README_MD"
+rm -f "$README_MD.bak"
+
 print_step "Version bump complete!"
 echo ""
 echo "Files updated:"
 echo "  - packages/join-block/readme.txt"
 echo "  - packages/join-block/join.php"
 echo "  - packages/join-flow/src/index.tsx"
+echo "  - README.md"
 echo ""
 echo "Next steps:"
 echo "  1. Review changes: git diff"


### PR DESCRIPTION
## Summary
- Removes the hard-coded `$addTags[] = "Unconfirmed";` line in `ZetkinService::addPerson` that tagged every newly created Zetkin person with "Unconfirmed"
- Bumps plugin version to 1.4.3 (readme.txt, join.php, index.tsx Sentry release)

## Context
The default tag was applied unconditionally inside the token-based `addPerson` flow, independent of the per-plan `add_tags` / `remove_tags` configuration and the `ck_join_flow_add_tags` / `ck_join_flow_zetkin_add_tags` filters. New Zetkin records will no longer receive this tag automatically. Tags supplied via membership plan config or filters continue to work unchanged.

No existing tests in `packages/join-block/tests/` covered this behaviour, so no test updates were required.

## Test plan
- [ ] Deploy 1.4.3 to staging
- [ ] Submit a join-flow signup wired to Zetkin with token credentials configured
- [ ] Confirm the new Zetkin person is created without an "Unconfirmed" tag
- [ ] Confirm tags from membership plan `add_tags` and from `ck_join_flow_add_tags` filter hooks are still applied
- [ ] Confirm `remove_tags` still apply correctly
- [ ] Promote to production once staging verified