### PR TITLE
Fix Mailchimp 400 on supporter-mode signups (v1.4.3)

### DIFF
--- a/packages/join-block/join.php
+++ b/packages/join-block/join.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name:     Common Knowledge Join Flow
  * Description:     Common Knowledge join flow plugin.
- * Version:         1.5.0
+ * Version:         1.4.3
  * Author:          Common Knowledge <hello@commonknowledge.coop>
  * Text Domain:     common-knowledge-join-flow
  * License: GPLv2 or later

--- a/packages/join-block/join.php
+++ b/packages/join-block/join.php
@@ -3,7 +3,7 @@
 /**
  * Plugin Name:     Common Knowledge Join Flow
  * Description:     Common Knowledge join flow plugin.
- * Version:         1.4.2
+ * Version:         1.5.0
  * Author:          Common Knowledge <hello@commonknowledge.coop>
  * Text Domain:     common-knowledge-join-flow
  * License: GPLv2 or later

--- a/packages/join-block/readme.txt
+++ b/packages/join-block/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, subscription, join
 Contributors: commonknowledgecoop
 Requires at least: 5.4
 Tested up to: 6.8
-Stable tag: 1.4.2
+Stable tag: 1.5.0
 Requires PHP: 8.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -107,6 +107,8 @@ Need help? Contact us at [hello@commonknowledge.coop](mailto:hello@commonknowled
 
 == Changelog ==
 
+= 1.5.0 =
+* Fix Mailchimp 400 on supporter-mode signups by omitting empty address merge fields
 = 1.4.2 =
 *
 = 1.4.1 =

--- a/packages/join-block/readme.txt
+++ b/packages/join-block/readme.txt
@@ -4,7 +4,7 @@ Tags: membership, subscription, join
 Contributors: commonknowledgecoop
 Requires at least: 5.4
 Tested up to: 6.8
-Stable tag: 1.5.0
+Stable tag: 1.4.3
 Requires PHP: 8.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -107,7 +107,7 @@ Need help? Contact us at [hello@commonknowledge.coop](mailto:hello@commonknowled
 
 == Changelog ==
 
-= 1.5.0 =
+= 1.4.3 =
 * Fix Mailchimp 400 on supporter-mode signups by omitting empty address merge fields
 = 1.4.2 =
 *

--- a/packages/join-block/src/Services/MailchimpService.php
+++ b/packages/join-block/src/Services/MailchimpService.php
@@ -19,24 +19,37 @@ class MailchimpService
             return [];
         }
 
-        $mergeFields = [
-            "FNAME" => $data['firstName'],
-            "LNAME" => $data['lastName'],
-            "PHONE" => $data['phoneNumber'],
-            "ADDRESS" => [
-                "addr1" => $data["addressLine1"],
-                "addr2" => $data["addressLine2"],
-                "city" => $data["addressCity"],
-                "state" => "",
-                "zip" => $data["addressPostcode"],
-                "country" => $data["addressCountry"]
-            ]
-        ];
+        $mergeFields = [];
+
+        if (!empty($data['firstName'])) {
+            $mergeFields['FNAME'] = $data['firstName'];
+        }
+        if (!empty($data['lastName'])) {
+            $mergeFields['LNAME'] = $data['lastName'];
+        }
+        if (!empty($data['phoneNumber'])) {
+            $mergeFields['PHONE'] = $data['phoneNumber'];
+        }
+
+        // ADDRESS is a structured Mailchimp merge field. Only emit it when we
+        // have a street address to send — supporter-mode forms don't collect
+        // an address, and Mailchimp rejects the whole request with 400 if the
+        // ADDRESS sub-fields arrive as nulls against a required merge field.
+        if (!empty($data['addressLine1'])) {
+            $mergeFields['ADDRESS'] = [
+                'addr1'   => $data['addressLine1'],
+                'addr2'   => $data['addressLine2'] ?? '',
+                'city'    => $data['addressCity'] ?? '',
+                'state'   => '',
+                'zip'     => $data['addressPostcode'] ?? '',
+                'country' => $data['addressCountry'] ?? '',
+            ];
+        }
 
         $customFieldsConfig = $data['customFieldsConfig'] ?? [];
         foreach ($customFieldsConfig as $customField) {
-            $mergeField = strtoupper(preg_replace('/[^A-Z_]/i', '_', $customField["id"]));
-            $mergeFields[$mergeField] = $data[$customField["id"]] ?? "";
+            $mergeField = strtoupper(preg_replace('/[^A-Z_]/i', '_', $customField['id']));
+            $mergeFields[$mergeField] = $data[$customField['id']] ?? '';
         }
 
         return $mergeFields;

--- a/packages/join-block/src/Services/MailchimpService.php
+++ b/packages/join-block/src/Services/MailchimpService.php
@@ -13,7 +13,7 @@ use CommonKnowledge\JoinBlock\Settings;
 
 class MailchimpService
 {
-    public static function buildMergeFields($data): array
+    public static function buildMergeFields(array $data): array
     {
         if ($data['isUpdateFlow']) {
             return [];

--- a/packages/join-block/src/Services/MailchimpService.php
+++ b/packages/join-block/src/Services/MailchimpService.php
@@ -13,6 +13,35 @@ use CommonKnowledge\JoinBlock\Settings;
 
 class MailchimpService
 {
+    public static function buildMergeFields($data): array
+    {
+        if ($data['isUpdateFlow']) {
+            return [];
+        }
+
+        $mergeFields = [
+            "FNAME" => $data['firstName'],
+            "LNAME" => $data['lastName'],
+            "PHONE" => $data['phoneNumber'],
+            "ADDRESS" => [
+                "addr1" => $data["addressLine1"],
+                "addr2" => $data["addressLine2"],
+                "city" => $data["addressCity"],
+                "state" => "",
+                "zip" => $data["addressPostcode"],
+                "country" => $data["addressCountry"]
+            ]
+        ];
+
+        $customFieldsConfig = $data['customFieldsConfig'] ?? [];
+        foreach ($customFieldsConfig as $customField) {
+            $mergeField = strtoupper(preg_replace('/[^A-Z_]/i', '_', $customField["id"]));
+            $mergeFields[$mergeField] = $data[$customField["id"]] ?? "";
+        }
+
+        return $mergeFields;
+    }
+
     private static function getClient()
     {
         $mailchimp_api_key = Settings::get("MAILCHIMP_API_KEY");
@@ -65,29 +94,7 @@ class MailchimpService
         $addTags = apply_filters('ck_join_flow_mailchimp_add_tags', $addTags, $data);
         $removeTags = apply_filters('ck_join_flow_mailchimp_remove_tags', $removeTags, $data);
 
-        if ($data['isUpdateFlow']) {
-            $mergeFields = [];
-        } else {
-            $mergeFields = [
-                "FNAME" => $data['firstName'],
-                "LNAME" => $data['lastName'],
-                "PHONE" => $data['phoneNumber'],
-                "ADDRESS" => [
-                    "addr1" => $data["addressLine1"],
-                    "addr2" => $data["addressLine2"],
-                    "city" => $data["addressCity"],
-                    "state" => "",
-                    "zip" => $data["addressPostcode"],
-                    "country" => $data["addressCountry"]
-                ]
-            ];
-
-            $customFieldsConfig = $data['customFieldsConfig'] ?? [];
-            foreach ($customFieldsConfig as $customField) {
-                $mergeField = strtoupper(preg_replace('/[^A-Z_]/i', '_', $customField["id"]));
-                $mergeFields[$mergeField] = $data[$customField["id"]] ?? "";
-            }
-        }
+        $mergeFields = self::buildMergeFields($data);
 
         $memberData = [
             "email_address" => $email,

--- a/packages/join-block/tests/MailchimpServiceTest.php
+++ b/packages/join-block/tests/MailchimpServiceTest.php
@@ -140,6 +140,59 @@ class MailchimpServiceTest extends TestCase
     }
 
     /**
+     * A donor with a full postal address but no phone number must receive
+     * ADDRESS while PHONE is omitted. The two fields are gated independently.
+     */
+    public function testAddressEmittedWhenPhoneMissing(): void
+    {
+        $data = [
+            'isUpdateFlow'    => '',
+            'firstName'       => 'Test',
+            'lastName'        => 'Person',
+            'phoneNumber'     => '',
+            'addressLine1'    => '1 Test Street',
+            'addressLine2'    => 'Flat 2',
+            'addressCity'     => 'London',
+            'addressPostcode' => 'SW1A 1AA',
+            'addressCountry'  => 'GB',
+        ];
+
+        $result = MailchimpService::buildMergeFields($data);
+
+        $this->assertArrayNotHasKey('PHONE', $result);
+        $this->assertArrayHasKey('ADDRESS', $result);
+        $this->assertSame('1 Test Street', $result['ADDRESS']['addr1']);
+    }
+
+    /**
+     * When addressLine1 is present but the optional sub-fields (addressLine2
+     * and the rest) are missing from $data, each optional sub-field must
+     * fall through to an empty string rather than null, so Mailchimp never
+     * sees a null in the ADDRESS payload.
+     */
+    public function testAddressSubFieldsDefaultToEmptyStringWhenMissing(): void
+    {
+        $data = [
+            'isUpdateFlow' => '',
+            'firstName'    => 'Test',
+            'lastName'     => 'Person',
+            'phoneNumber'  => '',
+            'addressLine1' => '1 Test Street',
+        ];
+
+        $result = MailchimpService::buildMergeFields($data);
+
+        $this->assertSame([
+            'addr1'   => '1 Test Street',
+            'addr2'   => '',
+            'city'    => '',
+            'state'   => '',
+            'zip'     => '',
+            'country' => '',
+        ], $result['ADDRESS']);
+    }
+
+    /**
      * Custom fields from customFieldsConfig are uppercased, non-letter
      * characters stripped, and the value passed through verbatim.
      */

--- a/packages/join-block/tests/MailchimpServiceTest.php
+++ b/packages/join-block/tests/MailchimpServiceTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace CommonKnowledge\JoinBlock\Tests;
+
+use CommonKnowledge\JoinBlock\Services\MailchimpService;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for MailchimpService::buildMergeFields.
+ *
+ * Exercises the pure merge-field construction extracted from
+ * MailchimpService::signup. Running these in isolation avoids the need
+ * to mock Mailchimp's HTTP client.
+ */
+class MailchimpServiceTest extends TestCase
+{
+    /**
+     * Full join-flow data (with address) produces all four merge fields
+     * with populated sub-fields. Characterises the behaviour that existed
+     * before the supporter-mode address fix and must not regress.
+     */
+    public function testStandardFlowDataProducesAllMergeFields(): void
+    {
+        $data = [
+            'isUpdateFlow'    => '',
+            'firstName'       => 'Test',
+            'lastName'        => 'Person',
+            'phoneNumber'     => '07123456789',
+            'addressLine1'    => '1 Test Street',
+            'addressLine2'    => 'Flat 2',
+            'addressCity'     => 'London',
+            'addressPostcode' => 'SW1A 1AA',
+            'addressCountry'  => 'GB',
+        ];
+
+        $result = MailchimpService::buildMergeFields($data);
+
+        $this->assertSame('Test', $result['FNAME']);
+        $this->assertSame('Person', $result['LNAME']);
+        $this->assertSame('07123456789', $result['PHONE']);
+        $this->assertSame([
+            'addr1'   => '1 Test Street',
+            'addr2'   => 'Flat 2',
+            'city'    => 'London',
+            'state'   => '',
+            'zip'     => 'SW1A 1AA',
+            'country' => 'GB',
+        ], $result['ADDRESS']);
+    }
+
+    /**
+     * Update flow still yields an empty merge-fields array regardless of
+     * what else is in the data.
+     */
+    public function testUpdateFlowReturnsEmptyMergeFields(): void
+    {
+        $data = [
+            'isUpdateFlow' => true,
+            'firstName'    => 'Test',
+            'lastName'     => 'Person',
+        ];
+
+        $this->assertSame([], MailchimpService::buildMergeFields($data));
+    }
+
+    /**
+     * Custom fields from customFieldsConfig are uppercased, non-letter
+     * characters stripped, and the value passed through verbatim.
+     */
+    public function testCustomFieldsAreUppercasedAndIncluded(): void
+    {
+        $data = [
+            'isUpdateFlow'    => '',
+            'firstName'       => 'Test',
+            'lastName'        => 'Person',
+            'phoneNumber'     => '',
+            'addressLine1'    => '1 Test Street',
+            'addressLine2'    => '',
+            'addressCity'     => 'London',
+            'addressPostcode' => 'SW1A 1AA',
+            'addressCountry'  => 'GB',
+            'customFieldsConfig' => [
+                ['id' => 'date-of-birth'],
+                ['id' => 'how_heard'],
+            ],
+            'date-of-birth' => '1990-01-01',
+            'how_heard'     => 'Friend',
+        ];
+
+        $result = MailchimpService::buildMergeFields($data);
+
+        $this->assertSame('1990-01-01', $result['DATE_OF_BIRTH']);
+        $this->assertSame('Friend', $result['HOW_HEARD']);
+    }
+}

--- a/packages/join-block/tests/MailchimpServiceTest.php
+++ b/packages/join-block/tests/MailchimpServiceTest.php
@@ -64,6 +64,82 @@ class MailchimpServiceTest extends TestCase
     }
 
     /**
+     * Supporter-flow data has no address keys at all — those fields are
+     * never collected in supporter mode. The resulting merge fields must
+     * contain FNAME and LNAME only, with no ADDRESS or PHONE block. Before
+     * this fix, buildMergeFields included an ADDRESS sub-array of nulls,
+     * which Mailchimp rejected with a 400 "Invalid Resource" when the
+     * audience had ADDRESS marked required — the member was never created
+     * and tags were never applied. Regression test for that signup path.
+     */
+    public function testSupporterFlowDataOmitsMissingFields(): void
+    {
+        $data = [
+            'isUpdateFlow' => '',
+            'firstName'    => 'Test',
+            'lastName'     => 'Person',
+            'phoneNumber'  => '',
+        ];
+
+        $result = MailchimpService::buildMergeFields($data);
+
+        $this->assertSame('Test', $result['FNAME']);
+        $this->assertSame('Person', $result['LNAME']);
+        $this->assertArrayNotHasKey('ADDRESS', $result);
+        $this->assertArrayNotHasKey('PHONE', $result);
+    }
+
+    /**
+     * Partial address data (addressLine1 missing) must not emit an ADDRESS
+     * merge field at all. Either we have a meaningful postal address to
+     * send or we don't send the field.
+     */
+    public function testPartialAddressOmitsAddressBlock(): void
+    {
+        $data = [
+            'isUpdateFlow'    => '',
+            'firstName'       => 'Test',
+            'lastName'        => 'Person',
+            'phoneNumber'     => '',
+            'addressCity'     => 'London',
+            'addressPostcode' => 'SW1A 1AA',
+        ];
+
+        $result = MailchimpService::buildMergeFields($data);
+
+        $this->assertArrayNotHasKey('ADDRESS', $result);
+    }
+
+    /**
+     * Empty-string and missing-key inputs must produce identical merge
+     * fields. Defensive against PHP-8 implicit-null behaviour that lets
+     * nulls reach Mailchimp's JSON payload.
+     */
+    public function testEmptyStringInputsMatchMissingKeyInputs(): void
+    {
+        $withMissingKeys = MailchimpService::buildMergeFields([
+            'isUpdateFlow' => '',
+            'firstName'    => 'Test',
+            'lastName'     => 'Person',
+            'phoneNumber'  => '',
+        ]);
+
+        $withEmptyStrings = MailchimpService::buildMergeFields([
+            'isUpdateFlow'    => '',
+            'firstName'       => 'Test',
+            'lastName'        => 'Person',
+            'phoneNumber'     => '',
+            'addressLine1'    => '',
+            'addressLine2'    => '',
+            'addressCity'     => '',
+            'addressPostcode' => '',
+            'addressCountry'  => '',
+        ]);
+
+        $this->assertSame($withMissingKeys, $withEmptyStrings);
+    }
+
+    /**
      * Custom fields from customFieldsConfig are uppercased, non-letter
      * characters stripped, and the value passed through verbatim.
      */

--- a/packages/join-flow/src/index.tsx
+++ b/packages/join-flow/src/index.tsx
@@ -24,7 +24,7 @@ const init = () => {
   const sentryDsn = getEnvStr("SENTRY_DSN")
   Sentry.init({
     dsn: sentryDsn,
-    release: "1.5.0"
+    release: "1.4.3"
   });
 
   if (getEnv('USE_CHARGEBEE')) {

--- a/packages/join-flow/src/index.tsx
+++ b/packages/join-flow/src/index.tsx
@@ -24,7 +24,7 @@ const init = () => {
   const sentryDsn = getEnvStr("SENTRY_DSN")
   Sentry.init({
     dsn: sentryDsn,
-    release: "1.4.1"
+    release: "1.5.0"
   });
 
   if (getEnv('USE_CHARGEBEE')) {

--- a/readme.md
+++ b/readme.md
@@ -95,7 +95,7 @@ All integrations are optional. Enable and configure them via environment variabl
 | **Auth0** | Creates user accounts with email, name, and role assignment on successful join. Requires an M2M application — see [Auth0 Setup](#auth0-setup). |
 | **Zetkin** | Adds members to campaigns, applies plan-specific tags, syncs custom fields (DOB, "hear about us", contact preferences). |
 | **Action Network** | Adds or updates people in Action Network; applies and removes tags; syncs custom fields. |
-| **Mailchimp** | Adds subscribers to mailing lists with plan-specific tags. Manages "lapsed" tag on payment failure/recovery. |
+| **Mailchimp** | Adds subscribers to mailing lists with plan-specific tags. Manages "lapsed" tag on payment failure/recovery. **Supporter-mode forms**: the flow does not collect a postal address, so the Mailchimp audience must have the `ADDRESS` merge field marked optional (not required); otherwise Mailchimp will reject new-member requests with a 400. |
 | **Sentry** | Real-time error tracking for both frontend and backend. |
 | **Google Cloud Logging** | Centralised log aggregation. |
 | **Microsoft Teams** | Error alert notifications via incoming webhook. |


### PR DESCRIPTION
## Summary
- Root-cause fix for Mailchimp `400 Invalid Resource` on supporter-mode signups, which was silently preventing all supporter donors from being added to Mailchimp (and therefore from being tagged).
- Extracts `MailchimpService::buildMergeFields` as a pure, unit-tested helper and gates each merge field on presence. Supporter-mode data (no address, no phone) now yields `FNAME` + `LNAME` only — no nulled `ADDRESS` block — and Mailchimp accepts the request.
- Patch version bump to 1.4.3.

## Context
Live trace on `tenantsunion.org.uk` (`testsupporter@commonknowledge.coop`, 2026-04-23T17:28:32) showed Mailchimp rejecting the supporter signup because `MailchimpService::signup` unconditionally built an `ADDRESS` merge field using `$data["addressLine1"]` etc. — keys that don't exist for supporter-mode data — which arrived at Mailchimp as `null`. The audience had `ADDRESS` marked required, so the whole `addListMember` POST was rejected, no member was created, and therefore no tags were applied. The reported symptom was "supporter-mode tags aren't being set"; the real cause was that the signup never landed.

## Changes
- `packages/join-block/src/Services/MailchimpService.php` — extract `buildMergeFields(array $data): array`; gate `FNAME` / `LNAME` / `PHONE` / `ADDRESS` on presence of their source data.
- `packages/join-block/tests/MailchimpServiceTest.php` — new unit tests covering standard, update, supporter, partial-address, empty-string-vs-missing-key, address-with-no-phone, missing-sub-field defaults, and custom-field cases.
- `readme.md` — Mailchimp integration row now documents that the audience's `ADDRESS` merge field must be optional when the block is used in supporter mode.
- Version bumped to 1.4.3 (`readme.txt`, `join.php`, `index.tsx` Sentry release).

## Known out of scope
- The custom-amount tag inheritance bug in supporter mode (donor enters a non-preset amount → wrong tier's tags applied). Reproducer tests are on branch `fix/supporter-mode-custom-amount-tag-inheritance`. Separate follow-up.
- Sibling services (`ZetkinService`, `ActionNetworkService`) have the same unconditional `$data["addressLine1"]` access pattern. Zetkin's upstream tolerates the null payload (observed passing on the Apr-23 trace) so not acute; worth a follow-up cleanup.